### PR TITLE
Maint/drop support for python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.3",
+    python_requires=">=3.8",
     install_requires=required,
     install_lib="mcdapy",
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.7",
+    python_requires=">=3.3",
     install_requires=required,
     install_lib="mcdapy",
 )


### PR DESCRIPTION
Numpy is no longer supporting 3.7, so neither does mcdapy now